### PR TITLE
Resolve GitHub issue number 5

### DIFF
--- a/app/components/historical-comparison.gjs
+++ b/app/components/historical-comparison.gjs
@@ -141,7 +141,9 @@ import abs from '../helpers/abs.js';
               as |priceDiff|
             }}
               {{#let
-                (calculatePercentageChange @historical.twoWeeks.price @latestPrice)
+                (calculatePercentageChange
+                  @historical.twoWeeks.price @latestPrice
+                )
                 as |percentChange|
               }}
                 <div

--- a/app/components/historical-comparison.gjs
+++ b/app/components/historical-comparison.gjs
@@ -10,6 +10,65 @@ import abs from '../helpers/abs.js';
 <template>
   {{#if @historical}}
     <div class="stats historical-stats">
+      {{#if @historical.day}}
+        <div class="stat-card historical-card">
+          <div class="stat-label">1 Day Ago</div>
+          <div class="stat-value" style="font-size: 1.3em;">{{formatPrice
+              @historical.day.price
+            }}
+            PLUR</div>
+          {{#if @latestPrice}}
+            {{#let
+              (subtract @latestPrice @historical.day.price)
+              as |priceDiff|
+            }}
+              {{#let
+                (calculatePercentageChange @historical.day.price @latestPrice)
+                as |percentChange|
+              }}
+                <div
+                  class="detail-value
+                    {{if (gt priceDiff 0) 'percentage-increase'}}
+                    {{if (lt priceDiff 0) 'percentage-decrease'}}"
+                  style="margin-top: 8px; font-size: 1.1em;"
+                >
+                  {{if (gt priceDiff 0) "↑"}}
+                  {{if (lt priceDiff 0) "↓"}}
+                  {{formatPrice (abs priceDiff)}}
+                  PLUR
+                </div>
+                <div
+                  class="detail-value
+                    {{if (gt priceDiff 0) 'percentage-increase'}}
+                    {{if (lt priceDiff 0) 'percentage-decrease'}}"
+                  style="font-size: 0.95em;"
+                >
+                  {{if (gt priceDiff 0) "↑"}}
+                  {{if (lt priceDiff 0) "↓"}}
+                  {{formatNumber
+                    (abs percentChange)
+                    minimumFractionDigits=2
+                    maximumFractionDigits=2
+                  }}%
+                </div>
+              {{/let}}
+            {{/let}}
+          {{/if}}
+          <div style="margin-top: 8px; font-size: 0.8em;">
+            <a
+              href="https://gnosisscan.io/block/{{@historical.day.blockNumber}}"
+              target="_blank"
+              rel="noopener noreferrer"
+              style="color: #667eea; text-decoration: none;"
+            >
+              Block #{{formatNumber @historical.day.blockNumber}}
+            </a>
+          </div>
+          <div style="font-size: 0.75em; color: #888; margin-top: 4px;">
+            {{formatDateTime @historical.day.timestamp}}
+          </div>
+        </div>
+      {{/if}}
       {{#if @historical.week}}
         <div class="stat-card historical-card">
           <div class="stat-label">1 Week Ago</div>
@@ -66,6 +125,65 @@ import abs from '../helpers/abs.js';
           </div>
           <div style="font-size: 0.75em; color: #888; margin-top: 4px;">
             {{formatDateTime @historical.week.timestamp}}
+          </div>
+        </div>
+      {{/if}}
+      {{#if @historical.twoWeeks}}
+        <div class="stat-card historical-card">
+          <div class="stat-label">2 Weeks Ago</div>
+          <div class="stat-value" style="font-size: 1.3em;">{{formatPrice
+              @historical.twoWeeks.price
+            }}
+            PLUR</div>
+          {{#if @latestPrice}}
+            {{#let
+              (subtract @latestPrice @historical.twoWeeks.price)
+              as |priceDiff|
+            }}
+              {{#let
+                (calculatePercentageChange @historical.twoWeeks.price @latestPrice)
+                as |percentChange|
+              }}
+                <div
+                  class="detail-value
+                    {{if (gt priceDiff 0) 'percentage-increase'}}
+                    {{if (lt priceDiff 0) 'percentage-decrease'}}"
+                  style="margin-top: 8px; font-size: 1.1em;"
+                >
+                  {{if (gt priceDiff 0) "↑"}}
+                  {{if (lt priceDiff 0) "↓"}}
+                  {{formatPrice (abs priceDiff)}}
+                  PLUR
+                </div>
+                <div
+                  class="detail-value
+                    {{if (gt priceDiff 0) 'percentage-increase'}}
+                    {{if (lt priceDiff 0) 'percentage-decrease'}}"
+                  style="font-size: 0.95em;"
+                >
+                  {{if (gt priceDiff 0) "↑"}}
+                  {{if (lt priceDiff 0) "↓"}}
+                  {{formatNumber
+                    (abs percentChange)
+                    minimumFractionDigits=2
+                    maximumFractionDigits=2
+                  }}%
+                </div>
+              {{/let}}
+            {{/let}}
+          {{/if}}
+          <div style="margin-top: 8px; font-size: 0.8em;">
+            <a
+              href="https://gnosisscan.io/block/{{@historical.twoWeeks.blockNumber}}"
+              target="_blank"
+              rel="noopener noreferrer"
+              style="color: #667eea; text-decoration: none;"
+            >
+              Block #{{formatNumber @historical.twoWeeks.blockNumber}}
+            </a>
+          </div>
+          <div style="font-size: 0.75em; color: #888; margin-top: 4px;">
+            {{formatDateTime @historical.twoWeeks.timestamp}}
           </div>
         </div>
       {{/if}}

--- a/app/services/etherscan-api.js
+++ b/app/services/etherscan-api.js
@@ -166,7 +166,9 @@ export default class EtherscanApiService extends Service {
    */
   async getHistoricalPrices(currentBlock) {
     const periods = {
+      day: currentBlock - BLOCKS_PER_DAY,
       week: currentBlock - BLOCKS_PER_WEEK,
+      twoWeeks: currentBlock - BLOCKS_PER_WEEK * 2,
       month: currentBlock - BLOCKS_PER_MONTH,
       threeMonths: currentBlock - BLOCKS_PER_MONTH * 3,
       sixMonths: currentBlock - BLOCKS_PER_MONTH * 6,

--- a/demo/index.html
+++ b/demo/index.html
@@ -363,7 +363,9 @@
             
             const latestPrice = hexToDecimal(currentEvents[currentEvents.length - 1].data);
             const historicalBlocks = {
+                day: currentLatestBlock - BLOCKS_PER_DAY,
                 week: currentLatestBlock - BLOCKS_PER_WEEK,
+                twoWeeks: currentLatestBlock - (BLOCKS_PER_WEEK * 2),
                 month: currentLatestBlock - BLOCKS_PER_MONTH,
                 threeMonths: currentLatestBlock - (BLOCKS_PER_MONTH * 3),
                 sixMonths: currentLatestBlock - (BLOCKS_PER_MONTH * 6)
@@ -559,7 +561,9 @@
             }
 
             const periods = {
+                day: '1 Day Ago',
                 week: '1 Week Ago',
+                twoWeeks: '2 Weeks Ago',
                 month: '1 Month Ago',
                 threeMonths: '3 Months Ago',
                 sixMonths: '6 Months Ago'

--- a/tests/integration/components/historical-comparison-test.js
+++ b/tests/integration/components/historical-comparison-test.js
@@ -1,0 +1,98 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | historical-comparison', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders with historical data including new time periods', async function (assert) {
+    const latestPrice = 1000000;
+    const historical = {
+      day: {
+        price: 950000,
+        blockNumber: 38000000,
+        timestamp: 1700000000,
+      },
+      week: {
+        price: 900000,
+        blockNumber: 37900000,
+        timestamp: 1699000000,
+      },
+      twoWeeks: {
+        price: 850000,
+        blockNumber: 37800000,
+        timestamp: 1698000000,
+      },
+      month: {
+        price: 800000,
+        blockNumber: 37700000,
+        timestamp: 1697000000,
+      },
+      threeMonths: {
+        price: 700000,
+        blockNumber: 37400000,
+        timestamp: 1694000000,
+      },
+      sixMonths: {
+        price: 600000,
+        blockNumber: 37100000,
+        timestamp: 1691000000,
+      },
+    };
+
+    this.set('historical', historical);
+    this.set('latestPrice', latestPrice);
+
+    await render(
+      hbs`<HistoricalComparison @historical={{this.historical}} @latestPrice={{this.latestPrice}} />`
+    );
+
+    // Check that all time period labels are rendered
+    assert.dom('.stat-label').exists({ count: 6 });
+    assert.dom('.stat-label:nth-of-type(1)').hasText('1 Day Ago');
+    assert.dom('.stat-label:nth-of-type(2)').hasText('1 Week Ago');
+    assert.dom('.stat-label:nth-of-type(3)').hasText('2 Weeks Ago');
+    assert.dom('.stat-label:nth-of-type(4)').hasText('1 Month Ago');
+    assert.dom('.stat-label:nth-of-type(5)').hasText('3 Months Ago');
+    assert.dom('.stat-label:nth-of-type(6)').hasText('6 Months Ago');
+  });
+
+  test('it renders without historical data', async function (assert) {
+    this.set('historical', null);
+    this.set('latestPrice', 1000000);
+
+    await render(
+      hbs`<HistoricalComparison @historical={{this.historical}} @latestPrice={{this.latestPrice}} />`
+    );
+
+    // Should not render anything when no historical data
+    assert.dom('.stat-card').doesNotExist();
+  });
+
+  test('it renders partial historical data', async function (assert) {
+    const historical = {
+      day: {
+        price: 950000,
+        blockNumber: 38000000,
+        timestamp: 1700000000,
+      },
+      twoWeeks: {
+        price: 850000,
+        blockNumber: 37800000,
+        timestamp: 1698000000,
+      },
+    };
+
+    this.set('historical', historical);
+    this.set('latestPrice', 1000000);
+
+    await render(
+      hbs`<HistoricalComparison @historical={{this.historical}} @latestPrice={{this.latestPrice}} />`
+    );
+
+    // Should render only available periods
+    assert.dom('.stat-card').exists({ count: 2 });
+    assert.dom('.stat-label').exists({ count: 2 });
+  });
+});

--- a/tests/unit/services/etherscan-api-test.js
+++ b/tests/unit/services/etherscan-api-test.js
@@ -48,4 +48,79 @@ module('Unit | Service | etherscan-api', function (hooks) {
 
     service.apiKey = null;
   });
+
+  test('getHistoricalPrices calculates correct block numbers for all periods', async function (assert) {
+    const service = this.owner.lookup('service:etherscan-api');
+    const currentBlock = 38000000;
+
+    // Mock the getHistoricalPrice method to avoid actual API calls
+    const originalGetHistoricalPrice = service.getHistoricalPrice;
+    const calledBlocks = [];
+
+    service.getHistoricalPrice = async function (targetBlock) {
+      calledBlocks.push(targetBlock);
+      return {
+        price: 1000000,
+        blockNumber: targetBlock,
+        timestamp: Date.now(),
+        txHash: '0x123',
+      };
+    };
+
+    await service.getHistoricalPrices(currentBlock);
+
+    // Verify that getHistoricalPrice was called with correct block numbers
+    // BLOCKS_PER_DAY = 720 * 24 = 17,280
+    // BLOCKS_PER_WEEK = 720 * 24 * 7 = 120,960
+    // BLOCKS_PER_MONTH = 720 * 24 * 30 = 518,400
+    const expectedBlocks = [
+      currentBlock - 17280, // day (1 day ago)
+      currentBlock - 120960, // week (1 week ago)
+      currentBlock - 241920, // twoWeeks (2 weeks ago)
+      currentBlock - 518400, // month (1 month ago)
+      currentBlock - 1555200, // threeMonths (3 months ago)
+      currentBlock - 3110400, // sixMonths (6 months ago)
+    ];
+
+    assert.strictEqual(
+      calledBlocks.length,
+      6,
+      'getHistoricalPrice should be called 6 times'
+    );
+
+    for (const expectedBlock of expectedBlocks) {
+      assert.true(
+        calledBlocks.includes(expectedBlock),
+        `Should fetch data for block ${expectedBlock}`
+      );
+    }
+
+    // Restore original method
+    service.getHistoricalPrice = originalGetHistoricalPrice;
+  });
+
+  test('getHistoricalPrices returns data with correct period keys', async function (assert) {
+    const service = this.owner.lookup('service:etherscan-api');
+    const currentBlock = 38000000;
+
+    // Mock the getHistoricalPrice method
+    service.getHistoricalPrice = async function (targetBlock) {
+      return {
+        price: 1000000,
+        blockNumber: targetBlock,
+        timestamp: Date.now(),
+        txHash: '0x123',
+      };
+    };
+
+    const historical = await service.getHistoricalPrices(currentBlock);
+
+    // Verify all expected periods are present
+    assert.ok(historical.day, 'Should include day period');
+    assert.ok(historical.week, 'Should include week period');
+    assert.ok(historical.twoWeeks, 'Should include twoWeeks period');
+    assert.ok(historical.month, 'Should include month period');
+    assert.ok(historical.threeMonths, 'Should include threeMonths period');
+    assert.ok(historical.sixMonths, 'Should include sixMonths period');
+  });
 });


### PR DESCRIPTION
Implements issue #5 by adding three time period options:
- 1 Day Ago (new)
- 1 Week Ago (already existed, now properly ordered)
- 2 Weeks Ago (new)

Changes:
- Updated etherscan-api.js to fetch historical data for day and twoWeeks periods
- Added display components for the new periods in historical-comparison.gjs
- Updated demo/index.html to match the new time periods

The new periods appear before the existing monthly periods, providing users with more granular price tracking options.